### PR TITLE
Serialize nested message fields

### DIFF
--- a/examples/mdrop_to_json.py
+++ b/examples/mdrop_to_json.py
@@ -19,4 +19,4 @@ with jnx_bits.soupbin.file.SoupBinFile(sys.argv[1]) as soupbin:
     for msg in soupbin:
         if msg:
             msg = jnx_bits.mdrop.bytes_to_mdrop(msg)
-            print( json.dumps( { "type": msg.__class__.__name__, **(vars(msg)) }))
+            print(msg.to_json())

--- a/jnx_bits/common/messages.py
+++ b/jnx_bits/common/messages.py
@@ -21,4 +21,4 @@ class ApplicationMessageMixin:
         pass
 
     def to_json(self):
-        return json.dumps(vars(self))
+        return json.dumps( { "msg_type_name": self.__class__.__name__, **vars(self) }, default = lambda o: o.__dict__)


### PR DESCRIPTION
to_json currently fails with:

```
TypeError: Object of type MdOrderDetails is not JSON serializable
```
